### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "hautelook/phpass": ">=0.3",
-        "laravel/framework": ">=5.6 <=5.8"
+        "laravel/framework": "5.6 - 5.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "hautelook/phpass": ">=0.3",
-        "laravel/framework": "5.6 - 5.8"
+        "laravel/framework": ">=5.6 <5.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
According to Composer's docs (https://getcomposer.org/doc/articles/versions.md#hyphenated-version-range-), this should be equivalent to `>=5.6.0 <5.9`.

This would allow all versions of Laravel 5.8 to be used without you needing to update this project for every non-breaking minor release of Laravel.

**Note - I haven't tested it (I can't even install it with my version of Laravel 5.8.14)**

Pertains to issue #5 